### PR TITLE
Add bearer auth for native.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "headers"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime",
+ "sha-1",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +476,12 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
@@ -862,6 +893,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1046,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "futures-util",
  "getrandom",
+ "headers",
  "http",
  "hyper",
  "js-sys",

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -12,6 +12,7 @@ native = [
     "tokio/net",
     "tonic",
     "tower",
+    "headers",
 ]
 web = [
     "getrandom",
@@ -39,6 +40,7 @@ tungstenite = { version = "0.13.0", default-features = false }
 hyper = { version = "0.14.2", default-features = false, optional = true }
 tokio-tungstenite = { version = "0.14.0", optional = true }
 tonic = { version = "0.5.0", default-features = false, features = ["transport"], optional = true }
+headers = { version = "0.3.4", optional = true }
 
 # web
 getrandom = { version = "0.2.2", features = ["js"], optional = true }


### PR DESCRIPTION
The bearer token is resolved on each websocket connection. It is then
added as authorization header to the connection request. This only
works in non-browser environments, since browser does not allow
custom headers for websocket requests.