### PR TITLE
Add connect info api

### DIFF
--- a/examples/helloworld/src/server.rs
+++ b/examples/helloworld/src/server.rs
@@ -1,12 +1,12 @@
 use tonic_ws_transport::WsConnection;
 
 use futures_util::StreamExt;
-use tokio::net::TcpListener;
-use tokio_stream::wrappers::TcpListenerStream;
-use tonic::{transport::Server, Request, Response, Status};
-
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::server::TcpConnectInfo;
+use tonic::{transport::Server, Request, Response, Status};
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
@@ -21,7 +21,13 @@ impl Greeter for MyGreeter {
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
-        println!("Got a request: {:?}", request);
+        let addr = request.extensions().get::<TcpConnectInfo>().unwrap();
+
+        println!(
+            "Got a request: {:?} from ip {}",
+            request,
+            addr.remote_addr.unwrap()
+        );
 
         let reply = hello_world::HelloReply {
             message: format!("Hello {}!", request.into_inner().name),
@@ -39,6 +45,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let incoming = listener_stream.filter_map(|connection| async {
         match connection {
             Ok(tcp_stream) => {
+                let info = TcpConnectInfo {
+                    local_addr: tcp_stream.local_addr().ok(),
+                    remote_addr: tcp_stream.peer_addr().ok(),
+                };
                 let ws_stream = match tokio_tungstenite::accept_async(tcp_stream).await {
                     Ok(ws_stream) => ws_stream,
                     Err(e) => {
@@ -46,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         return None;
                     }
                 };
-                Some(Ok(WsConnection::from_combined_channel(ws_stream)))
+                Some(Ok(WsConnection::from_combined_channel(ws_stream, info)))
             }
             Err(e) => Some(Err(e)),
         }

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = { version = "0.3.12", default-features = false, features = ["sink
 http = "0.2.3"
 pin-project = "1.0.5"
 thiserror = "1.0.23"
-tokio = { version = "=1.34.0", default-features = false, features = ["rt"] }
+tokio = { version = "1.34.0", default-features = false, features = ["rt"] }
 tokio-util = { version = "0.6.3", default-features = false, features = ["io"] }
 tower = { version = "0.4.4", default-features = false, optional = true }
 tungstenite = { version = "0.20.0", default-features = false }

--- a/transport/src/web.rs
+++ b/transport/src/web.rs
@@ -43,6 +43,7 @@ pub async fn connect(dst: http::Uri) -> Result<super::WsConnection, Error> {
     Ok(super::WsConnection {
         sink: Box::new(messages_sink),
         reader: Box::new(tokio_util::io::StreamReader::new(bytes_stream)),
+        info: crate::EmptyConnectInfo,
     })
 }
 


### PR DESCRIPTION
This allows us to specify any ConnectInfo on incoming connections, so we can extract the client ip address in the handler